### PR TITLE
BUGFIX: Adjust declaration of MetadataAwareStringFrontend::getByTag()

### DIFF
--- a/Classes/Cache/MetadataAwareStringFrontend.php
+++ b/Classes/Cache/MetadataAwareStringFrontend.php
@@ -58,7 +58,7 @@ class MetadataAwareStringFrontend extends StringFrontend
     /**
      * {@inheritdoc}
      */
-    public function getByTag($tag)
+    public function getByTag($tag): array
     {
         $entries = parent::getByTag($tag);
         foreach ($entries as $identifier => $content) {


### PR DESCRIPTION
The return-type was added. So we have to do that, too.